### PR TITLE
Add fan_only support

### DIFF
--- a/custom_components/harmony_ac/climate.py
+++ b/custom_components/harmony_ac/climate.py
@@ -291,6 +291,8 @@ class HarmonyIRClimate(ClimateEntity, RestoreEntity):
 
         if operation_mode.lower() == HVAC_MODE_OFF:
             command = 'Off'
+        elif operation_mode.lower() == HVAC_MODE_FAN_ONLY:
+            command = "Fan" + fan_mode.capitalize()
         else:
             command = operation_mode.capitalize() + fan_mode.capitalize() + target_temperature.capitalize()
 


### PR DESCRIPTION
Adds a special command combination that sends Fan + fan_mode commands
without a target temperature when HVAC_OPERATION_MODE is set to FAN_ONLY